### PR TITLE
Use split_to instead of split_off when decoding invalid UTF-8 so that

### DIFF
--- a/src/string_decoder.rs
+++ b/src/string_decoder.rs
@@ -30,7 +30,7 @@ impl Decoder for StringDecoder {
         match str::from_utf8(&src) {
             Err(err) if err.valid_up_to() > 0 => {
                 // Split the bytes that are valid utf8 and turn it into &str.
-                let split_bytes = src.split_off(err.valid_up_to());
+                let split_bytes = src.split_to(err.valid_up_to());
                 let valid_str = unsafe { str::from_utf8_unchecked(&split_bytes) };
 
                 let (ref mut index, _) = self.incomplete;
@@ -55,7 +55,7 @@ impl Decoder for StringDecoder {
                 let (ref mut index, ref mut buf) = self.incomplete;
 
                 // Index is always less than 4, because of below.
-                buf[*index] = src.split_off(1)[0];
+                buf[*index] = src.split_to(1)[0];
                 *index += 1;
 
                 // Check if char is valid


### PR DESCRIPTION
bytes to still be decoded. aren't erased.

I believe by using `split_off` in `Decoder::decode`, you _intend_ for the `src` `BytesMut` to retain characters that have not been read yet? According to [docs](https://docs.rs/bytes/1.0.0/bytes/struct.BytesMut.html#method.split_to), the function you want is `split_to`.

I'm not certain this is a 100% fix, but this fixes a panic I was seeing with firmware that returns errant non-UTF8 bytes:

```
thread 'main' panicked at 'index out of bounds: the len is 0 but the index is 0', src\string_decoder.rs:58:31
```